### PR TITLE
FEAT: Test Elements & Minimum Refactor in Controller and service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -88,7 +88,20 @@
 			<version>2.8.6</version>
 		</dependency>
 
-
+		<!-- Mocking with Mockito -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.14.2</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Jackson for JSON parsing -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.18.3</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>io.swagger.core.v3</groupId>
@@ -140,22 +153,44 @@
 				<version>0.8.12</version>
 				<executions>
 					<execution>
-						<id>prepare-agent</id>
 						<goals>
 							<goal>prepare-agent</goal>
 						</goals>
 					</execution>
 					<execution>
 						<id>report</id>
-						<phase>verify</phase>
+						<phase>test</phase>
 						<goals>
 							<goal>report</goal>
 						</goals>
+						<configuration>
+							<excludes>
+								<exclude>/configurators/</exclude>
+							</excludes>
+						</configuration>
+					</execution>
+					<execution>
+						<id>jacoco-check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>PACKAGE</element>
+									<limits>
+										<limit>
+											<counter>CLASS</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.85</minimum>  <!--Porcentaje mínimo de cubrimiento para construir el proyecto-->
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
 </project>

--- a/src/main/java/eci/cvds/mod2/controllers/ElementsController.java
+++ b/src/main/java/eci/cvds/mod2/controllers/ElementsController.java
@@ -36,8 +36,11 @@ public class ElementsController {
     }
     @DeleteMapping("/{elementId}")
     public ResponseEntity<String> deleteElement(@PathVariable String elementId) {
+        // Verifica si el elemento existe llamando a getElementById
+        elementsService.getElementById(elementId);  // Esto asegura que el elemento se obtenga antes de intentar eliminarlo.
+
         elementsService.deleteElement(elementId);
-        return ResponseEntity.ok("Element successfully deleted ");
+        return ResponseEntity.ok("Element successfully deleted");
     }
     @PutMapping("/{elementId}")
     public ResponseEntity<String> updateElement(@PathVariable String elementId,@Valid @RequestBody RecreationalElement newElement){

--- a/src/test/java/eci/cvds/mod2/controllers/ElementsControllerTest.java
+++ b/src/test/java/eci/cvds/mod2/controllers/ElementsControllerTest.java
@@ -1,0 +1,167 @@
+package eci.cvds.mod2.controllers;
+
+import eci.cvds.mod2.exceptions.ElementException;
+import eci.cvds.mod2.exceptions.ElementNotFoundException;
+import eci.cvds.mod2.modules.RecreationalElement;
+import eci.cvds.mod2.services.ElementsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ElementsControllerTest {
+
+    @InjectMocks
+    private ElementsController elementsController;
+
+    @Mock
+    private ElementsService elementsService;
+
+    private RecreationalElement element;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        element = new RecreationalElement("1", "Ball", 10, "A round ball");
+        //element = new RecreationalElement();
+    }
+
+    @Test
+    void shouldGetElementById_Success() {
+        // Arrange
+        when(elementsService.getElementById("1")).thenReturn(element);
+
+        // Act
+        ResponseEntity<RecreationalElement> response = elementsController.getElementById("1");
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(element, response.getBody());
+        verify(elementsService, times(1)).getElementById("1");
+    }
+
+    @Test
+    void shouldThrowExceptionWhenElementNotFound() {
+        // Arrange: Simulamos que no se encuentra el elemento
+        when(elementsService.getElementById("999")).thenThrow(new ElementNotFoundException(ElementException.ELEMENT_NOT_FOUND));
+
+        // Act y Assert: Verificamos que se lanza una ElementNotFoundException cuando no se encuentra el elemento
+        ElementNotFoundException exception = assertThrows(ElementNotFoundException.class, () -> {
+            elementsController.getElementById("999");
+        });
+
+        // Verificamos el mensaje de la excepción
+        assertTrue(exception.getMessage().contains(ElementException.ELEMENT_NOT_FOUND));
+    }
+
+
+    @Test
+    void shouldCreateElement() {
+        // Arrange
+        when(elementsService.createElement(any(RecreationalElement.class))).thenReturn(element);
+
+        // Act
+        ResponseEntity<String> response = elementsController.createElement(element);
+
+        // Assert
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals("Element successfully created", response.getBody());
+        verify(elementsService, times(1)).createElement(any(RecreationalElement.class));
+    }
+
+    @Test
+    void shouldGetElementByName_Success() {
+        // Arrange: Crear un RecreationalElement para simular la respuesta del servicio
+        RecreationalElement element = new RecreationalElement("1", "Ball", 10, "A round ball");
+
+        // Simula la respuesta del servicio cuando se solicita un elemento por nombre
+        when(elementsService.getElementByName("Ball")).thenReturn(element);
+
+        // Act: Llamamos al método del controlador
+        ResponseEntity<RecreationalElement> response = elementsController.getElementByName("Ball");
+
+        // Assert: Verificamos que el código de estado sea OK (200)
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        // Verificamos que el cuerpo de la respuesta contenga el elemento esperado
+        assertEquals(element, response.getBody());
+
+        // Verificamos que el servicio haya sido llamado una vez con el nombre "Ball"
+        verify(elementsService, times(1)).getElementByName("Ball");
+    }
+
+
+
+    @Test
+    void shouldDeleteElement() {
+        // Arrange: Crear un objeto de RecreationalElement para simular su existencia
+        RecreationalElement elementToDelete = new RecreationalElement("1", "Ball", 10, "Description");
+
+        // Simula la búsqueda del elemento con ID "1" en el repositorio
+        when(elementsService.getElementById("1")).thenReturn(elementToDelete);
+
+        // Simula la eliminación del elemento
+        when(elementsService.deleteElement("1")).thenReturn(elementToDelete);
+
+        // Act: Llamamos al método de eliminación en el controlador
+        ResponseEntity<String> response = elementsController.deleteElement("1");
+
+        // Assert: Verificamos que la respuesta sea la esperada
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Element successfully deleted", response.getBody());
+
+        // Verificamos que getElementById y deleteElement se llamaron correctamente
+        verify(elementsService, times(1)).getElementById("1");  // Verifica que getElementById fue llamado
+        verify(elementsService, times(1)).deleteElement("1");  // Verifica que deleteElement fue llamado
+    }
+
+
+
+
+    @Test
+    void shouldUpdateElement() {
+        // Arrange: Crear un nuevo elemento con datos actualizados
+        RecreationalElement updatedElement = new RecreationalElement("1","Updated Ball", 15, "Updated description");
+
+        // Simula la búsqueda del elemento original
+        when(elementsService.getElementById("1")).thenReturn(new RecreationalElement("1", "Ball", 10, "Old description"));
+
+        // Simula la acción de guardar el elemento actualizado
+        when(elementsService.updateElement(eq("1"), any(RecreationalElement.class))).thenReturn(updatedElement);
+
+        // Act: Llamamos al método de actualización
+        ResponseEntity<String> response = elementsController.updateElement("1", updatedElement);
+
+        // Assert: Verificamos que la respuesta es correcta
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Element successfully updated", response.getBody());
+
+        // Verificamos que el método de actualización se haya llamado una vez
+        verify(elementsService, times(1)).updateElement(eq("1"), any(RecreationalElement.class));
+    }
+
+
+    @Test
+    void testGetAllElements() {
+        // Arrange
+        when(elementsService.getAll()).thenReturn(List.of(element));
+
+        // Act
+        List<RecreationalElement> elements = elementsController.getAll();
+
+        // Assert
+        assertNotNull(elements);
+        assertEquals(1, elements.size());
+        assertEquals(element, elements.get(0));
+        verify(elementsService, times(1)).getAll();
+    }
+}


### PR DESCRIPTION
Agregado test para el método getElementByName del ElementsController

Se ha creado un test unitario para verificar el comportamiento del método getElementByName del controlador ElementsController.

El test simula la respuesta del servicio ElementsService para devolver un RecreationalElement cuando se consulta por el nombre de un elemento.

Se asegura que el controlador:

Retorne una respuesta con el código de estado 200 OK.

El cuerpo de la respuesta contenga el objeto esperado.

El servicio haya sido llamado correctamente con el nombre del elemento.

Este test garantiza que el controlador responda correctamente cuando se busque un elemento por su nombre y cubre el flujo en la cobertura de JaCoCo.